### PR TITLE
Adding support for linux/arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,6 @@ jobs:
         with:
           context: ./
           file: Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ github.repository }}:latest


### PR DESCRIPTION
I was looking at testing one of my playbooks on Amazon Linux 2023 using your Docker image and noticed that it was only available  as a `linux/amd64` image. I did a quick check and was able to build the image as a `linux/arm64` and Ansible appeared to work as expected.

The only issue I noticed was that building the `arm64` image seems to take a long time on GitHub runner (about 1hr). Not 100% sure why (super fast locally) but as you can see from [here](https://github.com/carlosroman/docker-amazonlinux2023-ansible/actions/runs/6619813797/job/17992598409) the final image created was still able to run your Ansible check/test. This test was done using the following change [here](https://github.com/carlosroman/docker-amazonlinux2023-ansible/commit/9dc476d970c20a543ce0ef7bb33974f51ec3d3aa). If you think that change also useful I'd be happy to tidy it up and make a PR for it and other repos.